### PR TITLE
fix: Correct behavior to insert `<br>`

### DIFF
--- a/src/atsphinx/linebreak/__init__.py
+++ b/src/atsphinx/linebreak/__init__.py
@@ -35,7 +35,7 @@ def inject_line_break(app: Sphinx, doctree: nodes.document):
         # Consider using text.astext().splitlines() for robust line splitting.
         if "\n" not in text.astext():  # Use astext() for reliable newline check
             continue
-        
+
         # It's generally safer to work with copies or build a new list of nodes
         # rather than modifying the list while iterating or indexing into it.
         current_parent = text.parent
@@ -44,7 +44,7 @@ def inject_line_break(app: Sphinx, doctree: nodes.document):
 
         original_text_content = text.astext()
         lines = original_text_content.split("\n")
-        
+
         # Only proceed if there are actual line breaks resulting in multiple lines
         if len(lines) <= 1 and not original_text_content.endswith("\n"):
             continue
@@ -55,12 +55,16 @@ def inject_line_break(app: Sphinx, doctree: nodes.document):
                 new_nodes.append(nodes.Text(line_content))
             # Add line_break node after each line except the last one,
             # or if the original text ended with a newline.
-            if i < len(lines) - 1 or (i == len(lines) - 1 and original_text_content.endswith("\n") and len(lines) > 1):
-                 # Ensure not to add <br> if it's the very last empty string from a trailing newline
-                 # unless there was content before it.
-                if line_content or i < len(lines) -1 :
+            if i < len(lines) - 1 or (
+                i == len(lines) - 1
+                and original_text_content.endswith("\n")
+                and len(lines) > 1
+            ):
+                # Ensure not to add <br> if it's the very last empty string from a trailing newline
+                # unless there was content before it.
+                if line_content or i < len(lines) - 1:
                     new_nodes.append(line_break())
-        
+
         if not new_nodes:
             continue
 

--- a/src/atsphinx/linebreak/__init__.py
+++ b/src/atsphinx/linebreak/__init__.py
@@ -53,17 +53,16 @@ def inject_line_break(app: Sphinx, doctree: nodes.document):
         for i, line_content in enumerate(lines):
             if line_content:  # Add text node only if there is content
                 new_nodes.append(nodes.Text(line_content))
+
             # Add line_break node after each line except the last one,
             # or if the original text ended with a newline.
-            if i < len(lines) - 1 or (
-                i == len(lines) - 1
-                and original_text_content.endswith("\n")
-                and len(lines) > 1
-            ):
-                # Ensure not to add <br> if it's the very last empty string from a trailing newline
-                # unless there was content before it.
-                if line_content or i < len(lines) - 1:
-                    new_nodes.append(line_break())
+            if i == len(lines) - 1:
+                if len(lines) == 1 or not original_text_content.endswith("\n"):
+                    continue
+            # Ensure not to add <br> if it's the very last empty string from a trailing newline
+            # unless there was content before it.
+            if line_content or i < len(lines) - 1:
+                new_nodes.append(line_break())
 
         if not new_nodes:
             continue

--- a/src/atsphinx/linebreak/__init__.py
+++ b/src/atsphinx/linebreak/__init__.py
@@ -26,16 +26,49 @@ def inject_line_break(app: Sphinx, doctree: nodes.document):
     # NOTE: doctree["source"] has file path of source.
     # If it want to change proc by file type, see this.
     for text in doctree.findall(nodes.Text):
-        # NOTE: This may not catch CR+LF (windows) pattern.
-        if "\n" not in text:
+        # Check if the parent of the text node is a literal_block.
+        # If so, skip processing to preserve code block structure.
+        if isinstance(text.parent, nodes.literal_block):
             continue
-        splitted = [(nodes.Text(t), line_break()) for t in text.split("\n")]
-        items = [item for parts in splitted for item in parts][:-1]
-        p = text.parent
-        pos = p.children.index(text)
-        p.children.remove(text)
-        for idx, item in enumerate(items):
-            p.children.insert(pos + idx, item)
+
+        # NOTE: This may not catch CR+LF (windows) pattern.
+        # Consider using text.astext().splitlines() for robust line splitting.
+        if "\n" not in text.astext():  # Use astext() for reliable newline check
+            continue
+        
+        # It's generally safer to work with copies or build a new list of nodes
+        # rather than modifying the list while iterating or indexing into it.
+        current_parent = text.parent
+        if not current_parent:
+            continue
+
+        original_text_content = text.astext()
+        lines = original_text_content.split("\n")
+        
+        # Only proceed if there are actual line breaks resulting in multiple lines
+        if len(lines) <= 1 and not original_text_content.endswith("\n"):
+            continue
+
+        new_nodes = []
+        for i, line_content in enumerate(lines):
+            if line_content:  # Add text node only if there is content
+                new_nodes.append(nodes.Text(line_content))
+            # Add line_break node after each line except the last one,
+            # or if the original text ended with a newline.
+            if i < len(lines) - 1 or (i == len(lines) - 1 and original_text_content.endswith("\n") and len(lines) > 1):
+                 # Ensure not to add <br> if it's the very last empty string from a trailing newline
+                 # unless there was content before it.
+                if line_content or i < len(lines) -1 :
+                    new_nodes.append(line_break())
+        
+        if not new_nodes:
+            continue
+
+        # Replace the original text node with the new sequence of text and line_break nodes
+        text_pos = current_parent.index(text)
+        current_parent.pop(text_pos)
+        for i, new_node in enumerate(new_nodes):
+            current_parent.insert(text_pos + i, new_node)
 
 
 def setup(app: Sphinx):  # noqa: D103

--- a/tests/test-root/code.md
+++ b/tests/test-root/code.md
@@ -1,0 +1,6 @@
+# code-block
+
+```python
+ham = 42
+spam = None
+```

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -17,3 +17,12 @@ def test__it(app: SphinxTestApp):
     assert soup.p.br
     assert soup.p.text == "This isa pen."
     assert len(soup.p.find_all("br")) == 1
+
+
+@pytest.mark.sphinx("html")
+def test__code(app: SphinxTestApp):
+    """Test for code-block with highlighting."""
+    app.build()
+    soup = BeautifulSoup((app.outdir / "code.html").read_text(), "lxml")
+    _classes = soup.find("pre").parent.parent.get("class", [])  # got: 'body'
+    assert "highlight-python" in _classes


### PR DESCRIPTION
In a source with language specified code-block, it's broken parent nodes of syntax highlighting.
So this PR will be make collect behavior likes the case (helped by Claude 3.7).